### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Hassfest.yml
+++ b/.github/workflows/Hassfest.yml
@@ -1,5 +1,8 @@
 name: Hassfest
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hsk-dk/home-assistant-thermex/security/code-scanning/1](https://github.com/hsk-dk/home-assistant-thermex/security/code-scanning/1)

To resolve the issue, we will add an explicit `permissions` block to the workflow. Since the workflow appears to involve validating code using Hassfest, it likely does not require write access. We will set the `contents: read` permission at the root level of the workflow, ensuring it applies to all jobs. This change will enforce the principle of least privilege while maintaining functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
