### PR TITLE
Implement dual-threshold filter alert logic

### DIFF
--- a/custom_components/thermex_api/config_flow.py
+++ b/custom_components/thermex_api/config_flow.py
@@ -67,6 +67,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     default=self.entry.options.get("fan_alert_hours", 30)
                 ): int,
                 vol.Optional(
+                    "fan_alert_days",
+                    default=self.entry.options.get("fan_alert_days", 90)
+                ): int,
+                vol.Optional(
                     "fan_auto_off_delay",
                     default=self.entry.options.get("fan_auto_off_delay", 10),
                     description="Time in minutes before automatic fan turn-off"

--- a/custom_components/thermex_api/runtime_manager.py
+++ b/custom_components/thermex_api/runtime_manager.py
@@ -49,6 +49,21 @@ class RuntimeManager:
     def get_last_reset(self):
         return self._data.get("last_reset")
 
+    def get_days_since_reset(self):
+        """Get number of days since last filter reset."""
+        last_reset = self._data.get("last_reset")
+        if not last_reset:
+            return None
+        
+        try:
+            reset_time = datetime.fromisoformat(last_reset.replace("Z", "+00:00"))
+            now = utcnow()
+            days_diff = (now - reset_time).days
+            return days_diff
+        except (ValueError, AttributeError) as e:
+            _LOGGER.warning("Error calculating days since reset: %s", e)
+            return None
+
     def get_filter_time(self):
         # For clarity: filter time is always runtime hours
         return self.get_runtime_hours()

--- a/custom_components/thermex_api/sensor.py
+++ b/custom_components/thermex_api/sensor.py
@@ -35,6 +35,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     async_add_entities([
         LastResetSensor(hub, runtime_manager, device_info),
+        RuntimeHoursSensor(hub, runtime_manager, device_info),
         FilterTimeSensor(hub, runtime_manager, device_info),
         ConnectionStatusSensor(hub, runtime_manager, device_info),
         DelayedTurnOffSensor(hub, runtime_manager, device_info, entry.entry_id),

--- a/custom_components/thermex_api/translations/da.json
+++ b/custom_components/thermex_api/translations/da.json
@@ -23,10 +23,11 @@
         "title": "Thermex-indstillinger",
         "data": {
           "enable_decolight": "Aktivér Decolys",
-          "fan_alert_hours": "Filter rengøringsadvarsel efter (timer)",
-          "fan_alert_days": "Filter rengøringsadvarsel efter (dage)",
+          "fan_alert_hours": "Filter rengøringsadvarsel efter (driftstimer)",
+          "fan_alert_days": "Filter rengøringsadvarsel efter (dage siden nulstilling)",
           "fan_auto_off_delay": "Forsinket slukning timer (minutter)"
-        }
+        },
+        "description": "Filter alarm udløses når ENTEN driftstimer ELLER dage siden nulstilling overskrides."
       }
     }
   },
@@ -34,6 +35,9 @@
     "sensor": {
       "thermex_sensor_last_reset": {
         "name": "Sidste nulstilling af filtertid"
+      },
+      "thermex_sensor_runtime_hours": {
+        "name": "Filter driftstimer siden sidste nulstilling"
       },
       "thermex_sensor_filter_time": {
         "name": "Filtertid"

--- a/custom_components/thermex_api/translations/en.json
+++ b/custom_components/thermex_api/translations/en.json
@@ -22,18 +22,22 @@
       "init": {
         "title": "Thermex options",
         "data": {
-          "enable_decolight": "Activate DecoLight",
-          "fan_alert_hours": "Filter cleaning notice after (hours)",
-          "fan_alert_days": "Filter cleaning notice after (days)",
+          "enable_decolight": "Activate Ambient light",
+          "fan_alert_hours": "Grease filter cleaning notice after (runtime hours)",
+          "fan_alert_days": "Grease filter cleaning notice after (days since reset)",
           "fan_auto_off_delay": "Delayed turn-off timer (minutes)"
-        }
+        },
+        "description": "Filter alert triggers when EITHER runtime hours OR days since reset threshold is exceeded."
       }
     }
   },
   "entity": {
     "sensor": {
       "thermex_sensor_last_reset": {
-        "name": "Last filter time reset"
+        "name": "Last grease filter time reset"
+      },
+      "thermex_sensor_runtime_hours": {
+        "name": "Grease filter runtime since last reset"
       },
       "thermex_sensor_filter_time": {
         "name": "Filter time"

--- a/custom_components/thermex_api/translations/sv.json
+++ b/custom_components/thermex_api/translations/sv.json
@@ -23,10 +23,11 @@
         "title": "Thermex-inställningar",
         "data": {
           "enable_decolight": "Aktivera DecoLight",
-          "fan_alert_hours": "Notis för filterbyte efter (timmar)",
-          "fan_alert_days": "Notis för filterbyte efter (dagar)",
+          "fan_alert_hours": "Notis för filterbyte efter (driftstimmar)",
+          "fan_alert_days": "Notis för filterbyte efter (dagar sedan nollställning)",
           "fan_auto_off_delay": "Fördröjd avstängning timer (minuter)"
-        }
+        },
+        "description": "Filteralarm utlöses när ANTINGEN driftstimmar ELLER dagar sedan nollställning överskrids."
       }
     }
   },
@@ -34,6 +35,9 @@
     "sensor": {
       "thermex_sensor_last_reset": {
         "name": "Senaste nollställning av filtertiden"
+      },
+      "thermex_sensor_runtime_hours": {
+        "name": "Filter driftstimmar sedan senaste nollställning"
       },
       "thermex_sensor_filter_time": {
         "name": "Filtertid"


### PR DESCRIPTION
- Add get_days_since_reset() method to RuntimeManager
- Update binary sensor to trigger on EITHER runtime hours OR days since reset
- Add fan_alert_days option to config flow (default: 90 days)
- Enhanced binary sensor with detailed state attributes and trigger reasons
- Add RuntimeHoursSensor to display runtime hours separately
- Update translations for all languages (en, da, sv) with dual-threshold descriptions
- Special handling for new installations without reset date