### PR TITLE
Simplify config flow: make fan_auto_off_delay consistent with other i…

### DIFF
--- a/custom_components/thermex_api/config_flow.py
+++ b/custom_components/thermex_api/config_flow.py
@@ -72,22 +72,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): int,
                 vol.Optional(
                     "fan_auto_off_delay",
-                    default=self.entry.options.get("fan_auto_off_delay", 10),
-                    description="Time in minutes before automatic fan turn-off"
-                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=120)),
+                    default=self.entry.options.get("fan_auto_off_delay", 10)
+                ): int,
             })
             return self.async_show_form(
                 step_id="init", data_schema=data_schema
             )
-
-        # In the validation section
-        if user_input:
-            delay = user_input.get("fan_auto_off_delay", 10)
-            if not (1 <= delay <= 120):
-                return self.async_show_form(
-                    step_id="init", 
-                    data_schema=data_schema,
-                    errors={"fan_auto_off_delay": "invalid_delay_range"}
-                )
 
         return self.async_create_entry(title="Options", data=user_input)


### PR DESCRIPTION
…nt settings

- Remove vol.All validation and range constraints
- Remove description parameter
- Remove validation logic in async_step_init
- Now all settings use simple int type for consistency